### PR TITLE
add fallback whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const supportsHyperlinks = require('supports-hyperlinks');
 
 module.exports = (text, url, options = {}) => {
 	if (!supportsHyperlinks.stdout) {
-		return options.fallback ? options.fallback(text, url) : `${text} (${url})`;
+		return options.fallback ? options.fallback(text, url) : `${text} ( ${url} )`;
 	}
 
 	return ansiEscapes.link(text, url);


### PR DESCRIPTION
This should make links in fallback terminals still clickable. Previously they [appended a closing paren](https://github.com/sindresorhus/terminal-link/issues/11).